### PR TITLE
Fix failing Ubuntu tests for file_groupowner_var_log

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+# purpose of this scenario is to install the rsyslog package
+# and thus configure the syslog group. The group is required
+# for the Ubuntu check and remediations but is missing
+# in podman containers by default.
+
+chgrp syslog /var/log
+


### PR DESCRIPTION
Tests were failing because syslog group does not exist in podman containers. The added test scenario ensures that rsyslog is installed and the syslog group exists.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
